### PR TITLE
fix(deps): bump brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2754,9 +2754,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "@actions/github": "^9.1.0",
     "@octokit/webhooks": "^14.2.0",
     "minimatch": "^10.2.5"
+  },
+  "overrides": {
+    "brace-expansion@^5": "^5.0.6"
   }
 }


### PR DESCRIPTION
## What
Adds an npm `overrides` block with a targeted `brace-expansion@^5` selector pinning the 5.x line to `^5.0.6`. Regenerates `package-lock.json`: the top-level runtime `brace-expansion` moves from `5.0.5` → `5.0.6`.

## Why
Resolves Dependabot alert [#118](https://github.com/ringgo-uk/delete-merged-action/security/dependabot/118) — [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) / CVE-2026-45149 (medium): large numeric ranges in `brace-expansion` defeat the documented `max` DoS protection. Vulnerable range `>=5.0.0 <5.0.6`, patched in `5.0.6`. The runtime copy is reached via `minimatch ^10.2.5`.

## Why the `@^5` selector
The lockfile also has unrelated `brace-expansion@2.1.0` (under `glob`) and `brace-expansion@1.1.14` (under `test-exclude`) — different majors, **not** in the advisory's vulnerable range. The `@^5` selector restricts the override to the 5.x line so those are untouched.

## Remaining 5.0.5 copy is bundled inside npm
`node_modules/npm/node_modules/brace-expansion@5.0.5` is a **bundled** dependency of `npm@11.14.1` itself (pulled by dev-only `@semantic-release/npm`). Bundled deps ship inside the parent tarball and cannot be overridden from a downstream manifest; it is also dev-scope and not part of the action's runtime. This is a known upstream npm limitation and is outside the scope of alert #118 (which is on the runtime copy).

## Verification
- `package.json`: 3-line addition (new `overrides` block), original CRLF line endings preserved.
- `package-lock.json`: only the top-level `node_modules/brace-expansion` entry changes (version/resolved/integrity 5.0.5 → 5.0.6). No unrelated lockfile churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)